### PR TITLE
Fix `isSelf` issue

### DIFF
--- a/Moose-Blueprint-Models/FamixJavaMethod.extension.st
+++ b/Moose-Blueprint-Models/FamixJavaMethod.extension.st
@@ -26,19 +26,20 @@ FamixJavaMethod >> isCBInitializer [
 FamixJavaMethod >> isCBSetter [
 
 	| hasSelfAccess |
-
 	self isSetter ifTrue: [ ^ true ].
 
 	hasSelfAccess := self accesses anySatisfy: [ :each |
-		                 each variable isSelf ].
+		                 each variable isImplicitVariable and: [
+			                 each variable isSelf ] ].
 	(self accesses size = 2 and: [
 		 hasSelfAccess and: [ self parameters size = 1 ] ]) ifFalse: [
 		^ false ].
 
 	hasSelfAccess := self accesses anySatisfy: [ :acc1 |
 		                 acc1 previous isNotNil and: [
-			                 acc1 previous variable isSelf and: [
-				                 acc1 variable isAttribute ] ] ].
+			                 acc1 previous variable isImplicitVariable and: [
+				                 acc1 previous variable isSelf and: [
+					                 acc1 variable isAttribute ] ] ] ].
 
 	^ (self name beginsWith: 'set') and: [
 		  hasSelfAccess and: [ self outgoingInvocations isEmpty ] ]

--- a/Moose-Blueprint-Models/FamixStInvocation.extension.st
+++ b/Moose-Blueprint-Models/FamixStInvocation.extension.st
@@ -12,9 +12,10 @@ FamixStInvocation >> isAttributeInvocation [
 { #category : #'*Moose-Blueprint-Models' }
 FamixStInvocation >> isSelfInvocation [
 
-	(self receiver isNil or: [ 
-		 self sender isNil or: [ self receiver isImplicitVariable not ] ]) ifTrue: [ 
-		^ false ].
+	(self receiver isNil or: [
+		 self sender isNil or: [ self receiver isImplicitVariable not ] ])
+		ifTrue: [ ^ false ].
 
-	^ self receiver isSelf and: [ self sender isMethod ]
+	^ self receiver isImplicitVariable and: [
+		  self receiver isSelf and: [ self sender isMethod ] ]
 ]

--- a/Moose-Blueprint-Models/FamixTInvocationsReceiver.extension.st
+++ b/Moose-Blueprint-Models/FamixTInvocationsReceiver.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #FamixTInvocationsReceiver }
-
-{ #category : #'*Moose-Blueprint-Models' }
-FamixTInvocationsReceiver >> isSelf [
-
-	^ false
-]


### PR DESCRIPTION
Only use `isSelf` after checking it is an implicit variable. This aligns with how this method is used in Famix.