### PR TITLE
Remove call to isCBGetter and replace them by isGetter.

### DIFF
--- a/Moose-Blueprint-Models-Tests/CBPojoTest.class.st
+++ b/Moose-Blueprint-Models-Tests/CBPojoTest.class.st
@@ -98,7 +98,7 @@ CBPojoTest >> setUp [
 	constructor := (model newMethodNamed: 'constructor()')
 		               isConstructor: true;
 		               yourself.
-	getter := model newMethodNamed: 'getAttribute()'.
+	getter := (model newMethodNamed: 'getAttribute()') declaredType: (FamixJavaPrimitiveType new name: 'String'); yourself.
 	setter := (model newMethodNamed: 'setAttribute()')
 		          parameters: { (model newParameterNamed: 'anObject') };
 					declaredType: (FamixJavaPrimitiveType new name: 'void')
@@ -116,7 +116,7 @@ CBPojoTest >> setUp [
 { #category : 'tests' }
 CBPojoTest >> testIsGetter [
 
-	self assert: getter isCBGetter
+	self assert: getter isGetter
 ]
 
 { #category : 'tests' }

--- a/Moose-Blueprint-Models/CBAccessorsModel.class.st
+++ b/Moose-Blueprint-Models/CBAccessorsModel.class.st
@@ -65,7 +65,7 @@ CBAccessorsModel >> initialize [
 
 { #category : 'testing' }
 CBAccessorsModel >> isCBGetter [ 
-	^ entity isCBGetter 
+	^ entity isGetter 
 ]
 
 { #category : 'testing' }

--- a/Moose-Blueprint-Models/CBMethodModel.class.st
+++ b/Moose-Blueprint-Models/CBMethodModel.class.st
@@ -205,7 +205,7 @@ CBMethodModel >> isAbstractAndReimplemented [
 { #category : 'properties - boolean' }
 CBMethodModel >> isCBAccessor [
 
-	(entity isCBGetter or: [ entity isSetter ]) ifTrue: [ ^ #accessor ].
+	(entity isGetter or: [ entity isSetter ]) ifTrue: [ ^ #accessor ].
 	^ nil
 ]
 

--- a/Moose-Blueprint-Models/FamixJavaAttribute.extension.st
+++ b/Moose-Blueprint-Models/FamixJavaAttribute.extension.st
@@ -5,8 +5,7 @@ FamixJavaAttribute >> cbAccessors [
 
 	^ (self incomingAccesses collectAsSet: [ :each | each source ])
 		  select: [ :each |
-			  each isCBGetter or: [
-				  each isSetter or: [ each isLazyInitializer ] ] ]
+			  each isGetter or: [ each isSetter or: [ each isLazyInitializer ] ] ]
 ]
 
 { #category : '*Moose-Blueprint-Models' }

--- a/Moose-Blueprint-Models/FamixJavaMethod.extension.st
+++ b/Moose-Blueprint-Models/FamixJavaMethod.extension.st
@@ -2,7 +2,7 @@ Extension { #name : 'FamixJavaMethod' }
 
 { #category : '*Moose-Blueprint-Models' }
 FamixJavaMethod >> isCBGetter [
-
+self deprecated: 'please use isGetter'  transformWith:  '`@receiver isCBGetter' -> '`@receiver isGetter '.
 	self isGetter ifTrue: [ ^ true ].
 
 	(self accesses size = 1 and: [ self parameters size isZero ])
@@ -26,7 +26,7 @@ FamixJavaMethod >> isCBInitializer [
 FamixJavaMethod >> isCBSetter [
 
 	| hasSelfAccess |
-self deprecated: 'please use isSetter'  transformWith:  '`@receiver isCBSetter -> `@receiver isSetter '.
+self deprecated: 'please use isSetter'  transformWith:  '`@receiver isCBSetter' -> '`@receiver isSetter '.
 	self isSetter ifTrue: [ ^ true ].
 
 	hasSelfAccess := self accesses anySatisfy: [ :each |

--- a/Moose-Blueprint-Models/FamixTHasKind.extension.st
+++ b/Moose-Blueprint-Models/FamixTHasKind.extension.st
@@ -2,12 +2,12 @@ Extension { #name : 'FamixTHasKind' }
 
 { #category : '*Moose-Blueprint-Models' }
 FamixTHasKind >> isCBGetter [
-
+self deprecated: 'please use isGetter'  transformWith:  '`@receiver isCBGetter' -> '`@receiver isGetter '.
 	^ self isGetter or: [ self isLazyInitializer ]
 ]
 
 { #category : '*Moose-Blueprint-Models' }
 FamixTHasKind >> isCBSetter [
-
+self deprecated: 'please use isSetter'  transformWith:  '`@receiver isCBSetter' -> '`@receiver isSetter '.
 	^ self isSetter
 ]

--- a/Moose-Blueprint-Models/FamixTMethod.extension.st
+++ b/Moose-Blueprint-Models/FamixTMethod.extension.st
@@ -32,7 +32,7 @@ FamixTMethod >> inSameClassAs: aMethod [
 { #category : '*Moose-Blueprint-Models' }
 FamixTMethod >> isCBAccessor [
 
-	^ self isSetter or: [ self isCBGetter ]
+	^ self isSetter or: [ self isGetter ]
 ]
 
 { #category : '*Moose-Blueprint-Models' }


### PR DESCRIPTION
Deprecate isCBGetter methods
Correct deprecation of isCBSetter
Correct initialization of tests
Fix #21